### PR TITLE
Fix: Update editor logo URL and whitelist domain

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "canva-clone-ali.vercel.app",
       },
+      {
+        protocol: "https",
+        hostname: "i.ibb.co",
+      },
     ],
   },
 };

--- a/src/features/editor/components/logo.tsx
+++ b/src/features/editor/components/logo.tsx
@@ -7,7 +7,7 @@ export const Logo = () => {
       <div className="flex items-center gap-x-2 hover:opacity-75 transition h-[68px] px-4">
         <div className="w-8 h-8 relative">
           <Image 
-            src="/home/header/logo" 
+            src="https://i.ibb.co/xt4L65pK/Asset-13x.png" 
             alt="Wrecked Labs" 
             fill
             className="object-contain"


### PR DESCRIPTION
The logo in the editor header was not displaying correctly because it was using an incorrect path.

This commit updates the `src` prop of the `Image` component in `src/features/editor/components/logo.tsx` to use the correct external URL: `https://i.ibb.co/xt4L65pK/Asset-13x.png`.

Additionally, `next.config.mjs` has been updated to include `i.ibb.co` in the `images.remotePatterns` to allow Next.js to optimize images from this domain.