### PR TITLE
feat: Implement "Use this SVG" for AI-generated SVGs

### DIFF
--- a/src/app/(dashboard)/banner.tsx
+++ b/src/app/(dashboard)/banner.tsx
@@ -95,22 +95,22 @@ export const Banner = () => {
 
   const createProject = () => {
     if (!generatedSVG) return;
+
+    if (!generatedSVG.svg) {
+      toast.error("No SVG content found to save.");
+      return;
+    }
     
     try {
-      // Create a new project with the generated SVG
-      const project = storage.saveProject({
-        name: `AI: ${prompt.substring(0, 20)}${prompt.length > 20 ? '...' : ''}`,
-        json: JSON.stringify(generatedSVG),
-        width: 1080,
-        height: 1080,
-      });
+      // Store the generated SVG string in localStorage
+      localStorage.setItem("newlyGeneratedSvg", generatedSVG.svg);
       
-      toast.success("AI SVG project created!");
+      toast.success("SVG ready to be used!");
       setAiDialogOpen(false);
-      router.push(`/editor/${project.id}`);
+      router.push("/editor/new-from-ai");
     } catch (error) {
-      console.error("Error creating project:", error);
-      toast.error("Failed to create project: " + (error instanceof Error ? error.message : String(error)));
+      console.error("Error processing AI SVG:", error);
+      toast.error("Failed to process AI SVG: " + (error instanceof Error ? error.message : String(error)));
     }
   };
 

--- a/src/app/editor/new-from-ai/page.test.tsx
+++ b/src/app/editor/new-from-ai/page.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NewFromAiPage from './page'; // Adjust path as necessary
+import { svgStorage, svgNormalizer } from '@/lib/svg-utils';
+import { toast } from 'sonner';
+
+// Mock dependencies
+jest.mock('@/lib/svg-utils', () => ({
+  svgStorage: {
+    saveSVG: jest.fn(),
+  },
+  svgNormalizer: {
+    createDataUrl: jest.fn(),
+  },
+}));
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(), // Added info for initial load messages
+  },
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    back: jest.fn(), // Added back for the "Back to Dashboard" button
+  }),
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+describe('NewFromAiPage', () => {
+  const mockSvgContent = '<svg><circle cx="50" cy="50" r="40" fill="red" /></svg>';
+  const mockSvgName = 'Test AI SVG';
+  const mockDataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(mockSvgContent);
+
+  beforeEach(() => {
+    // Clear mocks and localStorage before each test
+    jest.clearAllMocks();
+    localStorageMock.clear();
+    // Mock implementations
+    (svgNormalizer.createDataUrl as jest.Mock).mockReturnValue(mockDataUrl);
+    (svgStorage.saveSVG as jest.Mock).mockReturnValue({ id: '123', name: mockSvgName, content: mockSvgContent, dataUrl: mockDataUrl, dateAdded: Date.now() });
+  });
+
+  test('loads SVG from localStorage and displays it', async () => {
+    localStorageMock.setItem('newlyGeneratedSvg', mockSvgContent);
+    render(<NewFromAiPage />);
+
+    // Check if SVG content is displayed (preview and textarea)
+    await waitFor(() => {
+      expect(screen.getByText(/Review Your AI Generated SVG/i)).toBeInTheDocument();
+      // Check preview (presence of SVG element might be tricky with dangerouslySetInnerHTML, check container)
+      const previewContainer = screen.getByLabelText('SVG Preview Container'); // Add aria-label to preview div for easier selection
+      expect(previewContainer).toBeInTheDocument();
+      expect(previewContainer.innerHTML).toContain(mockSvgContent);
+      
+      expect(screen.getByDisplayValue(mockSvgContent)).toBeInTheDocument(); // Textarea
+    });
+    
+    // Check if localStorage item is removed
+    expect(localStorageMock.getItem('newlyGeneratedSvg')).toBeNull();
+    expect(toast.info).toHaveBeenCalledWith('AI Generated SVG loaded successfully!');
+  });
+
+  test('shows message if no SVG is found in localStorage', async () => {
+    render(<NewFromAiPage />);
+    expect(screen.getByText(/Loading AI Generated SVG.../i)).toBeInTheDocument(); // Initial loading state
+    // After useEffect runs:
+    await waitFor(() => { // Added await waitFor for async state updates and toast calls
+      expect(toast.info).toHaveBeenCalledWith('No new AI SVG found in storage.');
+      expect(screen.getByText(/No SVG data found to display./i)).toBeInTheDocument(); // Ensure a message is shown
+    });
+  });
+
+  test('successfully saves SVG to library', async () => {
+    localStorageMock.setItem('newlyGeneratedSvg', mockSvgContent);
+    render(<NewFromAiPage />);
+
+    await waitFor(() => {
+      // Wait for SVG to load
+      expect(screen.getByText(/Review Your AI Generated SVG/i)).toBeInTheDocument();
+    });
+
+    // Set SVG name
+    const nameInput = screen.getByPlaceholderText(/Enter a name for the SVG/i);
+    fireEvent.change(nameInput, { target: { value: mockSvgName } });
+    expect(nameInput).toHaveValue(mockSvgName);
+
+    // Click save button
+    const saveButton = screen.getByRole('button', { name: /Save to My SVGs/i });
+    fireEvent.click(saveButton);
+
+    // Assertions
+    expect(svgNormalizer.createDataUrl).toHaveBeenCalledWith(mockSvgContent);
+    expect(svgStorage.saveSVG).toHaveBeenCalledWith(mockSvgContent, mockSvgName, mockDataUrl);
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(`SVG "${mockSvgName}" saved successfully!`);
+    });
+  });
+
+  test('shows error toast if SVG name is empty during save', async () => {
+    localStorageMock.setItem('newlyGeneratedSvg', mockSvgContent);
+    render(<NewFromAiPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Review Your AI Generated SVG/i)).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByPlaceholderText(/Enter a name for the SVG/i);
+    fireEvent.change(nameInput, { target: { value: '  ' } }); // Empty name
+
+    const saveButton = screen.getByRole('button', { name: /Save to My SVGs/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('SVG name cannot be empty. Please provide a name.');
+    });
+    expect(svgStorage.saveSVG).not.toHaveBeenCalled();
+  });
+
+  test('shows error toast if saving to library fails', async () => {
+    localStorageMock.setItem('newlyGeneratedSvg', mockSvgContent);
+    (svgStorage.saveSVG as jest.Mock).mockImplementation(() => {
+      throw new Error('Test save error');
+    });
+    render(<NewFromAiPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Review Your AI Generated SVG/i)).toBeInTheDocument();
+    });
+    
+    const nameInput = screen.getByPlaceholderText(/Enter a name for the SVG/i);
+    fireEvent.change(nameInput, { target: { value: mockSvgName } });
+
+    const saveButton = screen.getByRole('button', { name: /Save to My SVGs/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to save SVG: Test save error');
+    });
+  });
+});

--- a/src/app/editor/new-from-ai/page.tsx
+++ b/src/app/editor/new-from-ai/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation'; // Imported in case of future redirection needs
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input'; // Added Input import
+import { svgStorage, svgNormalizer } from '@/lib/svg-utils'; // Uncommented imports
+
+const NewFromAiPage = () => {
+  const [svgContent, setSvgContent] = useState<string | null>(null);
+  const [svgName, setSvgName] = useState<string>(""); 
+  const [isLoading, setIsLoading] = useState(true); // Added isLoading state
+  const router = useRouter(); // Instantiated in case of future redirection needs
+
+  useEffect(() => {
+    setIsLoading(true); // Start loading
+    const storedSvg = localStorage.getItem("newlyGeneratedSvg");
+    if (storedSvg) {
+      setSvgContent(storedSvg);
+      // Using a more descriptive default name, including a part of the date for uniqueness
+      setSvgName(`AI Generated SVG - ${new Date().toISOString().split('T')[0]}`); 
+      localStorage.removeItem("newlyGeneratedSvg");
+      toast.info("AI Generated SVG loaded successfully!"); // Changed to toast.info
+    } else {
+      toast.info("No new AI SVG found in storage. You can generate one from the dashboard.");
+    }
+    setIsLoading(false); // Finish loading
+  }, []); // Empty dependency array ensures this runs once on mount
+
+  const handleSaveToLibrary = () => {
+    if (!svgContent) {
+      toast.error("No SVG content available to save.");
+      return;
+    }
+    if (!svgName.trim()) {
+      toast.error("SVG name cannot be empty. Please provide a name.");
+      return;
+    }
+
+    try {
+      const dataUrl = svgNormalizer.createDataUrl(svgContent);
+      const savedSVG = svgStorage.saveSVG(svgContent, svgName.trim(), dataUrl);
+
+      if (savedSVG) {
+        toast.success(`SVG "${savedSVG.name}" saved successfully!`);
+        // Optionally, disable the button or redirect, for now, just a toast
+      } else {
+        // This case might not be hit if saveSVG always throws on failure or returns a valid object.
+        toast.error("Failed to save SVG. Unknown error occurred.");
+      }
+    } catch (error) {
+      console.error("Error saving SVG to library:", error);
+      toast.error(`Failed to save SVG: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-4 text-center flex flex-col items-center justify-center min-h-screen">
+        <p className="text-lg text-muted-foreground mb-4">Loading AI Generated SVG...</p>
+      </div>
+    );
+  }
+
+  if (!svgContent) { // This condition is met if isLoading is false and svgContent is still null
+    return (
+      <div className="container mx-auto p-4 text-center flex flex-col items-center justify-center min-h-screen">
+        <p className="text-lg text-muted-foreground mb-4">No SVG data found to display.</p>
+        <Button onClick={() => router.push('/')} variant="outline">
+          Back to Dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8 space-y-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <h1 className="text-2xl sm:text-3xl font-semibold">Review Your AI Generated SVG</h1>
+        {/* Input for changing name can be added here or near the save button if desired in future */}
+      </div>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+        {/* SVG Preview Section */}
+        <div className="space-y-3">
+          <h2 className="text-xl font-medium">Preview</h2>
+          <div 
+            aria-label="SVG Preview Container" // Added aria-label
+            className="border rounded-lg p-4 bg-gray-50 dark:bg-gray-900 flex items-center justify-center"
+            style={{ 
+              minHeight: '300px', // Minimum height for the preview box
+              maxHeight: '500px', // Maximum height for the preview box
+              aspectRatio: '1/1'  // Maintain aspect ratio for the container
+            }}
+          >
+            <div
+              className="w-full h-full flex items-center justify-center"
+              dangerouslySetInnerHTML={{ __html: svgContent }} // svgContent is guaranteed to be non-null here
+            />
+          </div>
+        </div>
+
+        {/* SVG Code and Actions Section */}
+        <div className="space-y-3">
+          <h2 className="text-xl font-medium">SVG Code & Actions</h2>
+          <div className="space-y-4">
+            <textarea
+              readOnly
+              value={svgContent}
+              className="w-full h-64 md:h-80 p-3 border rounded-md font-mono text-sm bg-gray-100 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500"
+              aria-label="SVG Code"
+            />
+            <div className="space-y-2 mt-3">
+              <label htmlFor="svgNameInput" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                SVG Name:
+              </label>
+              <Input
+                id="svgNameInput"
+                type="text"
+                value={svgName}
+                onChange={(e) => setSvgName(e.target.value)}
+                placeholder="Enter a name for the SVG"
+                className="w-full"
+                disabled={!svgContent}
+              />
+            </div>
+            <Button onClick={handleSaveToLibrary} className="w-full sm:w-auto text-base py-3 px-6 mt-3">
+              Save to My SVGs
+            </Button>
+            <p className="text-xs text-muted-foreground mt-1">
+              Saving will add this SVG to your personal library.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NewFromAiPage;


### PR DESCRIPTION
This commit introduces the functionality for you to take an AI-generated SVG and open it in a dedicated review page.

Key changes:

1.  **Modified `src/app/(dashboard)/banner.tsx`**:
    *   The "Use This SVG" button (previously `createProject`) in the AI generation dialog no longer creates a standard project.
    *   Instead, it now stores the generated SVG content in `localStorage` under the key `newlyGeneratedSvg`.
    *   It then redirects you to a new page `/editor/new-from-ai`.

2.  **New Page `src/app/editor/new-from-ai/page.tsx`**:
    *   This page loads the SVG content from `localStorage` on mount and then clears the stored item.
    *   It displays the SVG in a preview panel using `dangerouslySetInnerHTML`.
    *   It shows the raw SVG code in a read-only textarea.
    *   It provides an input field for you to name the SVG (defaults to "AI SVG - {timestamp}").
    *   A "Save to My SVGs" button allows you to save the SVG to your library using `svgStorage.saveSVG` from `src/lib/svg-utils.ts`. Data URLs are generated via `svgNormalizer.createDataUrl`.
    *   Includes toast notifications for loading states and save operations.
    *   Manages loading and "not found" states gracefully.

3.  **Tests `src/app/editor/new-from-ai/page.test.tsx`**:
    *   Added Vitest/React Testing Library tests for the new page.
    *   Tests cover:
        *   Loading SVG from `localStorage`.
        *   Displaying a message if no SVG is found.
        *   Successfully saving the SVG to the library.
        *   Error handling for empty SVG name and save failures.
    *   The main component was updated with an `aria-label` and refined loading/not-found states to support these tests.

This feature enhances the AI SVG generation workflow by allowing you to directly review and save your creations to your personal SVG library.